### PR TITLE
Allow placing aliases in a separate file

### DIFF
--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -17,6 +17,7 @@ const BASE_CONFIG = path.normalize(__dirname + '/../../config.json');
  * Default User Configuration
  */
 let DEFAULT_USER_CONFIG = path.normalize(os.homedir() + '/.rtm.json');
+let DEFAULT_ALIAS_CONFIG = path.normalize(os.homedir() + '/.rtm.aliases.json');
 
 
 /**
@@ -30,6 +31,7 @@ class Config {
    */
   constructor() {
     this.reset(DEFAULT_USER_CONFIG);
+    this.read(DEFAULT_ALIAS_CONFIG);
   }
 
   /**


### PR DESCRIPTION
This PR allows placing aliases in a separate config file ($HOME/.rtm.aliases.json) so you have the option of independently storing those in source control. Putting the $HOME/.rtm.json into source control is challenging because it contains private access keys to the RTM account (and it's good security practice to not store keys in github), so you have to jump through hoops in order to save your aliases. 

This is a simple work around for this, by having a second file read upon startup that loads in the aliases file after the default user config is loaded. There may be a better way, but this was the most straight forward.