### PR TITLE
Update planner.js - just added note

### DIFF
--- a/src/cmd/planner.js
+++ b/src/cmd/planner.js
@@ -359,7 +359,7 @@ function _displayTasks(tasks) {
  */
 function _calcWidths(colMinWidths, colMaxWidths) {
 
-  // Total Width Available
+  // Total Width Available (if running via cron change to: 'let widthTotal = 80' or however wide you want)
   let widthTotal = ws.width - 8;
 
   // Requested Total Width


### PR DESCRIPTION
Added comment when running rtm-cli planner from cron there obviously is no ws or width to calculate. Therefore it can just be set to a static number, whatever width you want. I have my cron script send me this via e-mail (after running through aha to deal with ansi escape codes) so I found a width of 80 works well with my email client, etc.