### PR TITLE
Emoji indicators

### DIFF
--- a/config.json
+++ b/config.json
@@ -25,6 +25,7 @@
     "tags": "magenta",
     "due": "green"
   },
+  "iconType": "text",
   "aliases": [
     {
       "name": "overdue",

--- a/src/cmd/ls.js
+++ b/src/cmd/ls.js
@@ -97,14 +97,12 @@ function action(args, env) {
 
         // Print URL Indicator
         if ( task.url !== undefined ) {
-          // log.style('🔗', urlstyle);
-          printIndicator('url',task,'emoji');
+          printIndicator('url',task);
         }
 
         // Print Note Indicators
         for ( let i = 0; i < task.notes.length; i++ ) {
-          // log.style('📓', notestyle);
-          printIndicator('note',task,'emoji');
+          printIndicator('note',task);
         }
 
         // Print Tags

--- a/src/cmd/ls.js
+++ b/src/cmd/ls.js
@@ -6,6 +6,7 @@ const log = require('../utils/log.js');
 const finish = require('../utils/finish.js');
 const parseFilter = require('../utils/filter.js');
 const config = require('../utils/config.js');
+const printIndicator = require('../utils/printIndicator.js')
 
 
 /**
@@ -92,18 +93,18 @@ function action(args, env) {
         }
 
         // Add the Task Name
-        log.style(task.name, namestyle);
+        log.style(task.name+' ', namestyle);
 
         // Print URL Indicator
-        let urlstyle = task.isCompleted ? styles.completed : styles.url;
         if ( task.url !== undefined ) {
-          log.style('+', urlstyle);
+          // log.style('🔗', urlstyle);
+          printIndicator('url',task,'emoji');
         }
 
         // Print Note Indicators
-        let notestyle = task.isCompleted ? styles.completed : styles.notes;
         for ( let i = 0; i < task.notes.length; i++ ) {
-          log.style('*', notestyle);
+          // log.style('📓', notestyle);
+          printIndicator('note',task,'emoji');
         }
 
         // Print Tags

--- a/src/cmd/lsd.js
+++ b/src/cmd/lsd.js
@@ -108,16 +108,16 @@ function action(args, env) {
 
         // Print the Task Name
         log.style(' ');
-        log.style(task.name, priStyle);
+        log.style(task.name + ' ', priStyle);
 
         // Print URL Indicator
         if ( task.url !== undefined ) {
-          printIndicator('url',task,'emoji');
+          printIndicator('url',task);
         }
 
         // Print Note Indicators
         for ( let i = 0; i < task.notes.length; i++ ) {
-          printIndicator('note',task,'emoji');
+          printIndicator('note',task);
         }
 
         // Print Tags

--- a/src/cmd/lsd.js
+++ b/src/cmd/lsd.js
@@ -7,6 +7,7 @@ const log = require('../utils/log.js');
 const finish = require('../utils/finish.js');
 const parseFilter = require('../utils/filter.js');
 const config = require('../utils/config.js');
+const printIndicator = require('../utils/printIndicator.js')
 
 
 /**
@@ -110,15 +111,13 @@ function action(args, env) {
         log.style(task.name, priStyle);
 
         // Print URL Indicator
-        let urlstyle = task.isCompleted ? styles.completed : styles.url;
         if ( task.url !== undefined ) {
-          log.style('+', urlstyle);
+          printIndicator('url',task,'emoji');
         }
 
         // Print Note Indicators
-        let notestyle = task.isCompleted ? styles.completed : styles.notes;
         for ( let i = 0; i < task.notes.length; i++ ) {
-          log.style('*', notestyle);
+          printIndicator('note',task,'emoji');
         }
 
         // Print Tags

--- a/src/cmd/lsp.js
+++ b/src/cmd/lsp.js
@@ -82,16 +82,16 @@ function action(args, env) {
 
         // Print the Task Name
         log.style(' ');
-        log.style(task.name, priStyle);
+        log.style(task.name + ' ', priStyle);
 
         // Print URL Indicator
         if ( task.url !== undefined ) {
-          printIndicator('url',task,'emoji');
+          printIndicator('url',task);
         }
 
         // Print Note Indicators
         for ( let i = 0; i < task.notes.length; i++ ) {
-          printIndicator('note',task,'emoji');
+          printIndicator('note',task);
         }
 
         // Print Tags

--- a/src/cmd/lsp.js
+++ b/src/cmd/lsp.js
@@ -8,6 +8,7 @@ const finish = require('../utils/finish.js');
 const parseFilter = require('../utils/filter.js');
 const config = require('../utils/config.js');
 const styles = config.get().styles;
+const printIndicator = require('../utils/printIndicator.js')
 
 
 /**
@@ -84,15 +85,13 @@ function action(args, env) {
         log.style(task.name, priStyle);
 
         // Print URL Indicator
-        let urlstyle = task.isCompleted ? styles.completed : styles.url;
         if ( task.url !== undefined ) {
-          log.style('+', urlstyle);
+          printIndicator('url',task,'emoji');
         }
 
         // Print Note Indicators
-        let notestyle = task.isCompleted ? styles.completed : styles.notes;
         for ( let i = 0; i < task.notes.length; i++ ) {
-          log.style('*', notestyle);
+          printIndicator('note',task,'emoji');
         }
 
         // Print Tags

--- a/src/utils/printIndicator.js
+++ b/src/utils/printIndicator.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const config = require('./config.js');
+const log = require('./log.js');
+
+/**
+ * 
+ * @param {string} type note|url
+ * @param {object} task the task to print the indicator
+ * @param {string} style emoji|text
+ */
+function printIndicator(type,task,style) {
+    let styles = config.get().styles;
+
+    let indicatorStyle = task.isCompleted ? styles.completed : styles[type];
+    let noteIndicator,urlIndicator;
+    switch (style) {
+        case 'emoji':
+            noteIndicator = '📓';
+            urlIndicator = '🔗'
+        break;
+        case 'text':  
+        default:
+            noteIndicator = '*';
+            urlIndicator = '+'
+        break;
+    }
+    let indicators = {
+        note: noteIndicator,
+        url: urlIndicator
+    }
+    log.style(indicators[type], indicatorStyle);
+}
+
+module.exports = printIndicator;

--- a/src/utils/printIndicator.js
+++ b/src/utils/printIndicator.js
@@ -9,12 +9,14 @@ const log = require('./log.js');
  * @param {object} task the task to print the indicator
  * @param {string} style emoji|text
  */
-function printIndicator(type,task,style) {
+function printIndicator(type,task) {
     let styles = config.get().styles;
+    let iconType = config.get().iconType;
 
     let indicatorStyle = task.isCompleted ? styles.completed : styles[type];
     let noteIndicator,urlIndicator;
-    switch (style) {
+    iconType = iconType || 'text'; // defaults to text if nothing included
+    switch (iconType) {
         case 'emoji':
             noteIndicator = '📓';
             urlIndicator = '🔗'


### PR DESCRIPTION
Adds new config property `iconType` to display emoji indicators. 

`iconType` can be `emoji` or `text` and if nothing is specified, it will default to `text`, so as to not break any existing installations.

urls are indicated with 🔗  and notes are indicated with 📓 

There is a new utility `printIndicator()` that is used to print the indicator for the various ls* commands and this could be extended for displaying unicode strings as well for different icon types.