### PR TITLE
Modifies the lsd command to group by date, not date-time

### DIFF
--- a/src/cmd/lsd.js
+++ b/src/cmd/lsd.js
@@ -50,7 +50,8 @@ function action(args, env) {
       // Parse each task
       for ( let i = 0; i < tasks.length; i++ ) {
         let task = tasks[i];
-        let taskDue = task.due === undefined ? 0 : task.due.getTime();
+        let taskDue = task.due === undefined ? 0 : task.due.getDate();
+        let taskDueTime = task.due === undefined ? 0 : task.due.getTime();
 
         // ==== PRINT DUE DATE ==== //
 
@@ -128,13 +129,16 @@ function action(args, env) {
           log.style('#' + task.tags[i], tagstyle);
         }
 
-        // Print Completed Date
+        // Print Completed Date or Due Time
         if ( task.completed ) {
           log.style(' ');
           log.style('x', styles.completed);
           log.style(' ');
           log.style(df(task.completed, config.get().dateformat), styles.completed);
-        }
+        } else {
+	  // Prints due time for incomplete tasks that have a time set
+	  df(taskDueTime,'shortTime') != '12:00 AM' ? log.style(' '+df(taskDueTime,'shortTime'),styles.due) : null;
+	}
 
         // Finish line
         log('');

--- a/src/cmd/lsd.js
+++ b/src/cmd/lsd.js
@@ -136,9 +136,11 @@ function action(args, env) {
           log.style(' ');
           log.style(df(task.completed, config.get().dateformat), styles.completed);
         } else {
-	  // Prints due time for incomplete tasks that have a time set
-	  df(taskDueTime,'shortTime') != '12:00 AM' ? log.style(' '+df(taskDueTime,'shortTime'),styles.due) : null;
-	}
+          // Prints due time for incomplete tasks that have a time set
+          df(taskDueTime,'shortTime') != '12:00 AM' && taskDueTime!= 0 
+            ? log.style(' '+df(taskDueTime,'shortTime'),styles.due) 
+            : null;
+        }
 
         // Finish line
         log('');


### PR DESCRIPTION
The current lsd command groups tasks by date-time, so that if you have a
task due at 1PM and 2PM on the same day, it will get multiple entries
BUT they will all say the due date, e.g August 28. This groups tasks
returned by `lsd` by date, ordered by the due time and if the task has a
non-midnight time assigned to it, will display the time due.